### PR TITLE
docs: fix to broken markdown format

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ```
 
 Astro は `src/pages/` ディレクトリにある `.astro` または `.md` ファイルを探します。各ページは、そのファイル名に基づいてルートとして公開されます。
-src/components/` には特別なものはありませんが、Astro/React/Vue/Svelte/Preactのコンポーネントはここに置くのが好ましいでしょう。
+`src/components/` には特別なものはありませんが、Astro/React/Vue/Svelte/Preactのコンポーネントはここに置くのが好ましいでしょう。
 画像のような静的なアセットがあれば、`public/` ディレクトリに置くことができます。
 
 ## 🧞 Commands


### PR DESCRIPTION
READMEのインラインコード表示が壊れていたのを修正しました。
ライセンスやcontributionに対するポリシーが不明なので、もしPull Requestを受け付けないのであれば無視してください。